### PR TITLE
Rename the requirements files

### DIFF
--- a/.github/workflows/pr_approval.yaml
+++ b/.github/workflows/pr_approval.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: pip install pycodestyle
       - run: pip install pydocstyle
       - run: pip install pytest-cov
-      - run: pip install -r requirements.txt
+      - run: pip install -r testing-requirements.txt
       - run: pip install --upgrade importlib-metadata
       - name: Style checks
         run: make style

--- a/config.yaml
+++ b/config.yaml
@@ -41,8 +41,6 @@ service:
         class: logging.StreamHandler
         stream: ext://sys.stdout
         formatter: json
-        filters:
-          - context_filter
     formatters:
       brief:
         format: "%(message)s"
@@ -51,9 +49,6 @@ service:
         format: "%(filename)s %(lineno)d %(process)d %(levelname)s %(asctime)s %(name)s %(message)s"
       cloudwatch:
         format: "%(filename)s %(levelname)s %(asctime)s %(name)s %(hostname)s %(mac_address)s %(message)s"
-    filters:
-      context_filter:
-        (): "dvo_extractor.log_filter.LogFilter"
     root:
       handlers:
         - default

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+-i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
+
 app-common-python==0.2.5
 ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.5.2
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.7
+ccx-rules-ocp==2023.11.22

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,6 +1,3 @@
--i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
-
 app-common-python==0.2.5
 ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.5.2
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.7
-ccx-rules-ocp==2023.11.22


### PR DESCRIPTION
# Description

In https://github.com/RedHatInsights/dvo-extractor/pull/15 we forgot about using the requirements containing the rule version in the Dockerfile. So what I propose is:

1. Rename `deployment-requirements.txt` into `requirements.txt` so that it's the one used in the Dockerfile. It will also be the one used in the rules releaser pipeline. 
2. Rename `requirements.txt` into `testing-requirements.txt` and using it just for CI.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

locally using podmand build + podman run

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
