### PR TITLE
[CCXDEV-12207] Fix outgoing topic

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -263,7 +263,7 @@ parameters:
   value: platform.upload.announce
   required: true
 - name: CDP_OUTGOING_TOPIC
-  value: ccx.ocp.dvo
+  value: ccx.dvo.results
   required: true
 - name: CDP_DEAD_LETTER_QUEUE_TOPIC
   value: dvo.extractor.dead.letter.queue

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -132,7 +132,7 @@ objects:
         partitions: 1
         topicName: ${CDP_DEAD_LETTER_QUEUE_TOPIC}
       - replicas: 3
-        partitions: 2
+        partitions: 1
         topicName: ${CDP_OUTGOING_TOPIC}
       - replicas: 3
         partitions: 1

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -30,6 +30,7 @@ export IQE_FILTER_EXPRESSION="test_plugin_accessible"
 export IQE_REQUIREMENTS_PRIORITY=""
 export IQE_TEST_IMPORTANCE=""
 export IQE_CJI_TIMEOUT="30m"
+export IQE_ENV_VARS="DYNACONF_USER_PROVIDER__rbac_enabled=false"
 
 function changes_including_ocp_rules_version() {
     git log -1 HEAD . | grep "Bumped ccx-rules-ocp version"


### PR DESCRIPTION
# Description

While deploying the extractor in stage I found out that the topic was wrong. We created [ccx.dvo.results](https://github.com/RedHatInsights/platform-mq/blob/3081e087f0e2f0ddd3f1ead93f48534d9047d955/deploys/openshift/kafka-topics.yaml#L86) not `ccx.ocp.dvo`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
