### PR TITLE
[CCXDEV-12437] Enable new DVO formatter

### DIFF
--- a/config-devel.yaml
+++ b/config-devel.yaml
@@ -8,7 +8,7 @@ plugins:
 service:
   extract_timeout:
   extract_tmp_dir:
-  format: insights.formats._json.JsonFormat
+  format: ccx_ocp_core.core.formats.json.DVOWorkloadsJsonFormat
   target_components: []
   consumer:
     name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ plugins:
 service:
   extract_timeout:
   extract_tmp_dir:
-  format: insights.formats._json.JsonFormat
+  format: ccx_ocp_core.core.formats.json.DVOWorkloadsJsonFormat
   target_components: []
   consumer:
     name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -156,7 +156,7 @@ objects:
       service:
         extract_timeout:
         extract_tmp_dir:
-        format: insights.formats._json.JsonFormat
+        format: ccx_ocp_core.core.formats.json.DVOWorkloadsJsonFormat
         target_components: []
         consumer:
           name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,7 @@
 app-common-python==0.2.6
 ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.5.7
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.7
-ccx-rules-ocp==2023.11.22
+# TODO Revert back to only ccx-rules-ocp version once DVO rules are finished
+#ccx-rules-ocp==2023.11.22
+ccx-ocp-core @ git+https://gitlab.cee.redhat.com/ccx/ccx-ocp-core@master
+ccx-rules-ocp @ git+https://gitlab.cee.redhat.com/ccx/ccx-rules-ocpe@master


### PR DESCRIPTION
# Description

This change enables the use of new DVO formatter `ccx_ocp_core.core.formats.json.DVOWorkloadsJsonFormat`.
Also for testing it uses latest master branches of ccx-ocp-core and ccx-rules-ocp.

Fixes #CCXDEV-12437

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Bump-up dependent library (no changes in the code)
- Configuration update
