### PR TITLE
[CCXDEV-12208] Update the ccx-messaging version

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -266,7 +266,7 @@ parameters:
   value: ccx.dvo.results
   required: true
 - name: CDP_DEAD_LETTER_QUEUE_TOPIC
-  value: dvo.extractor.dead.letter.queue
+  value: ccx.dvo.extractor.dead.letter.queue
   required: true
 - name: PAYLOAD_TRACKER_TOPIC
   value: platform.payload-status

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
 
 app-common-python==0.2.6
-ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.5.7
+ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.6.0
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.7
 ccx-rules-ocp==2023.11.22


### PR DESCRIPTION
# Description

We are suffering the same issues that we solved in [CCXDEV-11808](https://issues.redhat.com/browse/CCXDEV-11808). However, the fix is newer than the ccx-messaging version we are using in this service.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
