### PR TITLE
Fix variable wrongly used

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -186,7 +186,7 @@ objects:
           - name: ccx_messaging.watchers.cluster_id_watcher.ClusterIdWatcher
           - name: ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher
             kwargs:
-              bootstrap.servers: ${KAFKA_BOOTSTRAP_URL}
+              bootstrap.servers: ${CDP_CONSUMER_SERVER}
               topic: ${PAYLOAD_TRACKER_TOPIC}
 
         logging:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -186,7 +186,7 @@ objects:
           - name: ccx_messaging.watchers.cluster_id_watcher.ClusterIdWatcher
           - name: ccx_messaging.watchers.payload_tracker_watcher.PayloadTrackerWatcher
             kwargs:
-              bootstrap.servers: $KAFKA_BOOTSTRAP_URL
+              bootstrap.servers: ${KAFKA_BOOTSTRAP_URL}
               topic: ${PAYLOAD_TRACKER_TOPIC}
 
         logging:


### PR DESCRIPTION
# Description

I found out this variable is never substituted because it doesn't use any brackets:

```
$ oc describe configmap dvo-extractor-config-map | grep "KAFKA_BOOTSTRAP_URL"
        bootstrap.servers: $KAFKA_BOOTSTRAP_URL
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Ephemeral.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
