### PR TITLE
[CCXDEV-12127] Fix payload-tracker support

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -197,6 +197,7 @@ objects:
             kwargs:
               bootstrap.servers: $KAFKA_BOOTSTRAP_URL
               topic: ${PAYLOAD_TRACKER_TOPIC}
+              service_name: dvo-extractor
 
         logging:
           version: 1


### PR DESCRIPTION
# Description

Add proper service_name for the payload tracker. Payload tracker is supported out-of-the-box by the insights-ccx-messaging library. This fixes the service name used for payload-tracker kafka messages.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)