### PR TITLE
[CCXDEV-12208] Add timeout to probes

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -99,6 +99,7 @@ objects:
             initialDelaySeconds: 20
             successThreshold: 1
             periodSeconds: 10
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /metrics
@@ -108,6 +109,7 @@ objects:
             successThreshold: 1
             failureThreshold: 1
             periodSeconds: 10
+            timeoutSeconds: 10
           startupProbe:
             httpGet:
               path: /metrics
@@ -118,6 +120,7 @@ objects:
             # Wait for 10x10 seconds
             failureThreshold: 10
             periodSeconds: 10
+            timeoutSeconds: 10
           volumeMounts:
             - mountPath: /data
               name: dvo-extractor-config


### PR DESCRIPTION
# Description

Pods are still restarting every now and often because liveness and readiness probes fail. We have had hundreds of restarts in the last few days. I read in https://stackoverflow.com/a/73142284 that the probe timeout could be an issue. I'm not sure if this would fix it as it's just happening in prod and I cannot reproduce it on stage nor ephemeral.

## Type of change

- Configuration update

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
