### PR TITLE
[CCXDEV-12445] Bump up ccx-messaging to 3.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
 
 app-common-python==0.2.6
-ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.6.0
+ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.6.1
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.7
 ccx-rules-ocp==2023.11.22

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ zip_safe = False
 packages = find:
 install_requires =
     app-common-python>=0.2.6
-    ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.5.9
+    ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.6.1
     insights-core>=3.2.23
     insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging
 


### PR DESCRIPTION
# Description

Introduces changes in https://github.com/RedHatInsights/insights-ccx-messaging/pull/143

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Bump-up dependent library (no changes in the code)

## Testing steps

See PR in ccx-messaging package mentioned above.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
