### PR TITLE
Bump up ccx-messaging in setup file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ zip_safe = False
 packages = find:
 install_requires =
     app-common-python>=0.2.6
-    ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.6.2
+    ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.6.3
     insights-core>=3.2.23
     insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging
 


### PR DESCRIPTION
# Description

Version of ccx-messaging was not updated in setup.cfg file (while it was in requirements file)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Bump-up dependent library (no changes in the code)
- Configuration update

## Testing steps

NA

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
