### PR TITLE
[CCXDEV-12791] Rename insights-results-smart-proxy to ccx-smart-proxy

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -21,7 +21,7 @@ export REF_ENV="insights-production"
 export COMPONENT_NAME="dvo-extractor"
 export IMAGE="quay.io/cloudservices/dvo-extractor"
 # NOTE: ccx-data-pipeline is required because iqe-ccx-plugin does some api queries in tests that require that.
-export COMPONENTS="ccx-data-pipeline ccx-insights-results dvo-writer dvo-extractor insights-content-service insights-results-smart-proxy ccx-mock-ams"  # space-separated list of components to laod
+export COMPONENTS="ccx-data-pipeline ccx-insights-results dvo-writer dvo-extractor insights-content-service ccx-smart-proxy ccx-mock-ams"  # space-separated list of components to laod
 export COMPONENTS_W_RESOURCES="dvo-extractor"  # component to keep
 export CACHE_FROM_LATEST_IMAGE="true"
 export DEPLOY_FRONTENDS="false"


### PR DESCRIPTION
# Description

This rename is needed in order to use the smart-proxy endpoint internally from other AppSRE namespaces. We used to have different app-sre component ID and clowdapp name which made it impossible.

## Type of change

- Configuration update

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
