### PR TITLE
Using latest version for ICM to allow OCPEngine to work properly

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -185,11 +185,16 @@ objects:
             heartbeat.interval.ms: 10000
             session.timeout.ms: 20000
             dead_letter_queue_topic: ${CDP_DEAD_LETTER_QUEUE_TOPIC}
+
         downloader:
           name: ccx_messaging.downloaders.http_downloader.HTTPDownloader
           kwargs:
             max_archive_size: 100MiB
             allow_unsafe_links: ${ALLOW_UNSAFE_LINKS}
+
+        engine:
+          name: ccx_messaging.engines.ocp_engine.OCPEngine
+
         publisher:
           name: ccx_messaging.publishers.dvo_metrics_publisher.DVOMetricsPublisher
           kwargs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 
 app-common-python==0.2.6
 ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.8.3
-insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.10
+insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
 ccx-rules-ocp==2024.05.07

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     app-common-python>=0.2.6
     ccx-messaging>=3.8.3
     insights-core>=3.2.23
-    insights-core-messaging>=1.2.10
+    insights-core-messaging>=1.2.11
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
# Description

This configuration and versioning update:
- Use OCPEngine instead of the default Engine, in order to ignore non-insights operator archives that can reach our pipleines.
- Use latest insights-core-messaging version with a fix for non-default engines

## Type of change

- New feature (non-breaking change which adds functionality)
- Bump-up dependent library (no changes in the code)

## Testing steps


## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
