### PR TITLE
Bump insights-ccx-messaging version to 3.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
 
 app-common-python==0.2.6
-ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.8.3
+ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v3.8.5
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
 ccx-rules-ocp==2024.05.07

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ zip_safe = False
 packages = find:
 install_requires =
     app-common-python>=0.2.6
-    ccx-messaging>=3.8.3
+    ccx-messaging>=3.8.5
     insights-core>=3.2.23
     insights-core-messaging>=1.2.11
 


### PR DESCRIPTION
# Description

Bump version of ccx-messaging to 3.8.5

Fixes # (issue)

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
