### PR TITLE
Replace == type comparisons with is comparisons

### DIFF
--- a/test/command_line_test.py
+++ b/test/command_line_test.py
@@ -42,7 +42,7 @@ def test_command_line_args_no_config_provided():
     with pytest.raises(SystemExit) as exception:
         sys.argv = ["dvo-extractor"]
         command_line.insights_dvo_extractor()
-    assert exception.type == SystemExit
+    assert exception.type is SystemExit
     assert exception.value.code == 1
 
 
@@ -53,7 +53,7 @@ def test_command_line_args_invalid_arg_provided(capsys):
 
         parser = command_line.parse_args()
 
-        assert exception.type == SystemExit
+        assert exception.type is SystemExit
         assert exception.value.code == 2
 
         assert not parser.config


### PR DESCRIPTION
# Description

Ruff in CI complains because of type comparisons. This PR replaces them with `is` comparisons.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Tests run successfully.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
