### PR TITLE
Adding ability to process runtime-recomendations

### DIFF
--- a/config-devel.yaml
+++ b/config-devel.yaml
@@ -1,6 +1,7 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
+    - runtime_ocp_rules
     - dvo_extractor
     - insights.specs.default
     - pythonjsonlogger

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
+    - runtime_ocp_rules
     - dvo_extractor
     - insights.specs.default
     - pythonjsonlogger

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -164,6 +164,7 @@ objects:
       plugins:
         packages:
           - ccx_rules_ocp.external.dvo
+          - runtime_ocp_rules
           - dvo_extractor
           - insights.specs.default
           - pythonjsonlogger

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ app-common-python==0.2.7
 ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.4
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
 ccx-rules-ocp==2024.11.19
+runtime-ocp-rules @ git+https://gitlab.cee.redhat.com/wabuahma/runtime-ocp-rules
 setuptools>=70.0.0


### PR DESCRIPTION
# Description

- Adding ability to process runtime recommendations rules to DVO-Extractor as proof of concept.  
- The runtimes recomendations repo was added to requirements.txt
- This MR is made on poc-runtimes branch as this is used only as the POC
- Those changes wont be merged to master


Fixes # [CCXDEV-14539](https://issues.redhat.com/browse/CCXDEV-14539)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Configuration update

## Testing steps

Those changes were validated in ephemeral with archives uploaded by https://gitlab.cee.redhat.com/ireyes/runtimes-poc-demonator and by checking dvo.results topic 

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
