### PR TITLE
Do Not Merge - Runtimes PoC

### DIFF
--- a/config-devel.yaml
+++ b/config-devel.yaml
@@ -1,6 +1,7 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
+    - runtime_ocp_rules
     - dvo_extractor
     - insights.specs.default
     - pythonjsonlogger

--- a/config-devel.yaml
+++ b/config-devel.yaml
@@ -1,7 +1,7 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
-    - runtime_ocp_rules.rules
+    - runtime_ocp_rules.external.rules
     - dvo_extractor
     - insights.specs.default
     - pythonjsonlogger
@@ -9,7 +9,7 @@ plugins:
 service:
   extract_timeout:
   extract_tmp_dir:
-  format: runtime_ocp_rules.core.json
+  format: runtime_ocp_rules.core.json.OCPRecommendationsJsonFormat
   target_components: []
   consumer:
     name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/config-devel.yaml
+++ b/config-devel.yaml
@@ -1,7 +1,7 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
-    - runtime_ocp_rules
+    - runtime_ocp_rules.rules
     - dvo_extractor
     - insights.specs.default
     - pythonjsonlogger

--- a/config-devel.yaml
+++ b/config-devel.yaml
@@ -8,7 +8,7 @@ plugins:
 service:
   extract_timeout:
   extract_tmp_dir:
-  format: ccx_ocp_core.core.formats.json.OCPRecommendationsJsonFormat
+  format: runtime_ocp_rules.core.json
   target_components: []
   consumer:
     name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
+    - runtime_ocp_rules
     - dvo_extractor
     - insights.specs.default
     - pythonjsonlogger

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
-    - runtime_ocp_rules.rules
+    - runtime_ocp_rules.external.rules
     - dvo_extractor
     - insights.specs.default
     - pythonjsonlogger
@@ -9,7 +9,7 @@ plugins:
 service:
   extract_timeout:
   extract_tmp_dir:
-  format: runtime_ocp_rules.core.json
+  format: runtime_ocp_rules.core.json.OCPRecommendationsJsonFormat
   target_components: []
   consumer:
     name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
-    - runtime_ocp_rules
+    - runtime_ocp_rules.rules
     - dvo_extractor
     - insights.specs.default
     - pythonjsonlogger

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ plugins:
 service:
   extract_timeout:
   extract_tmp_dir:
-  format: ccx_ocp_core.core.formats.json.OCPRecommendationsJsonFormat
+  format: runtime_ocp_rules.core.json
   target_components: []
   consumer:
     name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -171,7 +171,7 @@ objects:
       service:
         extract_timeout:
         extract_tmp_dir:
-        format: ccx_ocp_core.core.formats.json.OCPRecommendationsJsonFormat
+        format: runtime_ocp_rules.core.json
         target_components: []
         consumer:
           name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -164,6 +164,7 @@ objects:
       plugins:
         packages:
           - ccx_rules_ocp.external.dvo
+          - runtime_ocp_rules
           - dvo_extractor
           - insights.specs.default
           - pythonjsonlogger

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -164,7 +164,7 @@ objects:
       plugins:
         packages:
           - ccx_rules_ocp.external.dvo
-          - runtime_ocp_rules
+          - runtime_ocp_rules.rules
           - dvo_extractor
           - insights.specs.default
           - pythonjsonlogger

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -164,7 +164,7 @@ objects:
       plugins:
         packages:
           - ccx_rules_ocp.external.dvo
-          - runtime_ocp_rules.rules
+          - runtime_ocp_rules.external.rules
           - dvo_extractor
           - insights.specs.default
           - pythonjsonlogger
@@ -172,7 +172,7 @@ objects:
       service:
         extract_timeout:
         extract_tmp_dir:
-        format: runtime_ocp_rules.core.json
+        format: runtime_ocp_rules.core.json.OCPRecommendationsJsonFormat
         target_components: []
         consumer:
           name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ app-common-python==0.2.7
 ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.4
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
 ccx-rules-ocp==2024.11.19
+runtime-ocp-rules @ git+https://gitlab.cee.redhat.com/wabuahma/runtime-ocp-rules
 setuptools>=70.0.0


### PR DESCRIPTION
# Description

The poc-runtimes branch is used for runtimes PoC. The DVO-Extractor was adapted to be able to process the runtimes recommendations. This MR is used to build image in quay so it can be ran in Ephemeral environment.

!!!!DO NOT MERGE!!!!

Fixes # [CCXDEV-14539](https://issues.redhat.com/browse/CCXDEV-14539)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Configuration update

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
