### PR TITLE
Update formatter to be the one for runtimes

### DIFF
--- a/config-devel.yaml
+++ b/config-devel.yaml
@@ -8,7 +8,7 @@ plugins:
 service:
   extract_timeout:
   extract_tmp_dir:
-  format: ccx_ocp_core.core.formats.json.OCPRecommendationsJsonFormat
+  format: runtime_ocp_rules.core.json
   target_components: []
   consumer:
     name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ plugins:
 service:
   extract_timeout:
   extract_tmp_dir:
-  format: ccx_ocp_core.core.formats.json.OCPRecommendationsJsonFormat
+  format: runtime_ocp_rules.core.json
   target_components: []
   consumer:
     name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -171,7 +171,7 @@ objects:
       service:
         extract_timeout:
         extract_tmp_dir:
-        format: ccx_ocp_core.core.formats.json.OCPRecommendationsJsonFormat
+        format: runtime_ocp_rules.core.json
         target_components: []
         consumer:
           name: ccx_messaging.consumers.kafka_consumer.KafkaConsumer


### PR DESCRIPTION
Formatters are not completely independent from rules as they need to recognize them.

Related to [CCXDEV-14539](https://issues.redhat.com/browse/CCXDEV-14539)
