### PR TITLE
Bump ccx messaging version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
 
 app-common-python==0.2.7
-ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.6
+ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.7
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
 ccx-rules-ocp==2024.12.11
 setuptools>=70.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
 
 app-common-python==0.2.7
-ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.4
+ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.6
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
 ccx-rules-ocp==2024.12.11
 setuptools>=70.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
 
 app-common-python==0.2.7
-ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.7
+ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.8
 insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
 ccx-rules-ocp==2024.12.11
 setuptools>=70.0.0


### PR DESCRIPTION
# Description

Bump ccx messaging library version that includes a fix for a missing dependency.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
