### PR TITLE
ccx-messaging version bump and remove unnecessary packages from plugins config

### DIFF
--- a/config-devel.yaml
+++ b/config-devel.yaml
@@ -1,10 +1,6 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
-    - dvo_extractor
-    - insights.specs.default
-    - pythonjsonlogger
-    - pythonjsonlogger.jsonlogger
 service:
   extract_timeout:
   extract_tmp_dir:

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,6 @@
 plugins:
   packages:
     - ccx_rules_ocp.external.dvo
-    - dvo_extractor
-    - insights.specs.default
-    - pythonjsonlogger
-    - pythonjsonlogger.jsonlogger
 service:
   extract_timeout:
   extract_tmp_dir:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -164,10 +164,6 @@ objects:
       plugins:
         packages:
           - ccx_rules_ocp.external.dvo
-          - dvo_extractor
-          - insights.specs.default
-          - pythonjsonlogger
-          - pythonjsonlogger.jsonlogger
       service:
         extract_timeout:
         extract_tmp_dir:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://repository.engineering.redhat.com/nexus/repository/ccx/simple
 
 app-common-python==0.2.7
-ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.8
-insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
+ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.12
+insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.15
 ccx-rules-ocp==2025.01.14
 setuptools>=70.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,9 @@ zip_safe = False
 packages = find:
 install_requires =
     app-common-python>=0.2.6
-    ccx-messaging>=4.1.4
+    ccx-messaging>=4.1.12
     insights-core>=3.2.23
-    insights-core-messaging>=1.2.11
+    insights-core-messaging>=1.2.15
 
 [options.packages.find]
 exclude =

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,3 +1,3 @@
 app-common-python==0.2.7
-ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.4
-insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.11
+ccx-messaging @ git+https://github.com/RedHatInsights/insights-ccx-messaging@v4.1.12
+insights-core-messaging @ git+https://github.com/RedHatInsights/insights-core-messaging@1.2.15


### PR DESCRIPTION
# Description

Bumping ccx-messaging to 4.1.12 and core-messaging to 1.2.15

Remove unnecessary packages from plugins config

Related to [CCXDEV-14773](https://issues.redhat.com/browse/CCXDEV-14773)

Fixes # (issue)

## Type of change


- Bump-up dependent library (no changes in the code)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
